### PR TITLE
Overall rework of multiple loot tables

### DIFF
--- a/src/main/resources/assets/ancientwarfare/loot_tables/chests/dwarf.json
+++ b/src/main/resources/assets/ancientwarfare/loot_tables/chests/dwarf.json
@@ -1,86 +1,121 @@
 {
     "pools": [
         {
-            "name":"main", 
-            "rolls": {
-                "min": 3,
-                "max": 4
+            "name": "dwarf_weapon",
+            "rolls": 1,
+            "bonus_rolls": {
+                "min": 0,
+                "max": 1
             },
             "entries": [
                 {
                     "type": "item",
-                    "name": "stone",
-                    "weight": 6,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 2
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "torch",
-                    "weight": 6,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 6
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "mushroom_stew",
-                    "weight": 5,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 5
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "iron_ore",
-                    "weight": 6,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 6
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
                     "name": "ancientwarfarenpc:iron_halberd",
-                    "weight": 5,
+                    "weight": 1
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:iron_axe",
+                    "weight": 1
+                }
+            ]
+        },
+        {
+            "name": "dwarf_tools",
+            "rolls": {
+                "min": 1,
+                "max": 2
+            },
+            "bonus_rolls": {
+                "min": 1,
+                "max": 3
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:iron_pickaxe",
+                    "weight": 10
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:diamond_pickaxe",
+                    "weight": 1,
+                    "quality": 3,
                     "functions": [
                         {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 2
+                            "function": "enchant_with_levels",
+                            "treasure": true,
+                            "levels": {
+                                "min": 10,
+                                "max": 39
                             }
                         }
                     ]
                 },
                 {
                     "type": "item",
-                    "name": "iron_ingot",
-                    "weight": 2,
+                    "name": "minecraft:iron_shovel",
+                    "weight": 10
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:minecart",
+                    "weight": 5
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:rail",
+                    "weight": 5,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 16,
+                                "max": 64
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "raw_ores",
+            "rolls": {
+                "min": 2,
+                "max": 5
+            },
+            "bonus_rolls": {
+                "min": 1,
+                "max": 3
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:iron_ore",
+                    "weight": 10
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:gold_ore",
+                    "weight": 5
+                }
+            ]
+        },
+        {
+            "name": "processed_ores",
+            "rolls": {
+                "min": 1,
+                "max": 3
+            },
+            "bonus_rolls": {
+                "min": 1,
+                "max": 2
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:iron_ingot",
+                    "weight": 10,
                     "functions": [
                         {
                             "function": "set_count",
@@ -93,13 +128,68 @@
                 },
                 {
                     "type": "item",
-                    "name": "diamond",
+                    "name": "minecraft:gold_ingot",
+                    "weight": 5,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 2
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:diamond",
                     "weight": 1,
                     "functions": [
                         {
                             "function": "set_count",
                             "count": {
                                 "min": 1,
+                                "max": 2
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:emerald",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 2
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "rubble",
+            "rolls": {
+                "min": 1,
+                "max": 3
+            },
+            "bonus_rolls": {
+                "min": -2,
+                "max": 0
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:cobblestone",
+                    "weight": 10,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
                                 "max": 3
                             }
                         }
@@ -107,57 +197,64 @@
                 },
                 {
                     "type": "item",
-                    "name": "red_mushroom",
-                    "weight": 3,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 6
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "brown_mushroom",
-                    "weight": 3,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 6
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "cooked_mutton",
+                    "name": "minecraft:gravel",
                     "weight": 5,
                     "functions": [
                         {
                             "function": "set_count",
                             "count": {
                                 "min": 1,
-                                "max": 6
+                                "max": 3
                             }
                         }
                     ]
                 },
                 {
                     "type": "item",
-                    "name": "gold_ingot",
-                    "weight": 3,
+                    "name": "minecraft:flint",
+                    "weight": 2,
                     "functions": [
                         {
                             "function": "set_count",
                             "count": {
                                 "min": 1,
-                                "max": 7
+                                "max": 2
                             }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "food",
+            "rolls": {
+                "min": 1,
+                "max": 2
+            },
+            "bonus_rolls": {
+                "min": 1,
+                "max": 2
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:mushroom_stew",
+                    "weight": 5
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:rabbit_stew",
+                    "weight": 2
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:potion",
+                    "weight": 1,
+                    "quality": 3,
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{CustomPotionEffects: [{ShowParticles: 1b, Duration: 4800, Id: 3b, Amplifier: 0b}], CustomPotionColor: 16776960, display: {Lore: [\"Known to make you mine faster\"], Name: \"Dwarf's Brew\"}}"
                         }
                     ]
                 }

--- a/src/main/resources/assets/ancientwarfare/loot_tables/chests/gnome.json
+++ b/src/main/resources/assets/ancientwarfare/loot_tables/chests/gnome.json
@@ -1,58 +1,63 @@
 {
     "pools": [
         {
-            "name":"main", 
+            "name": "weapons",
             "rolls": {
-                "min": 1,
-                "max": 4
+                "min": 0,
+                "max": 1
             },
             "entries": [
                 {
                     "type": "item",
-                    "name": "milk_bucket",
-                    "weight": 6,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 2
-                            }
-                        }
-                    ]
+                    "name": "ancientwarfarenpc:iron_shield",
+                    "weight": 2
                 },
                 {
                     "type": "item",
-                    "name": "cooked_beef",
-                    "weight": 5,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 5
-                            }
-                        }
-                    ]
+                    "name": "minecraft:bow",
+                    "weight": 5
                 },
                 {
                     "type": "item",
-                    "name": "leather",
-                    "weight": 6,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 6
-                            }
-                        }
-                    ]
+                    "name": "minecraft:iron_sword",
+                    "weight": 2
                 },
                 {
                     "type": "item",
                     "name": "ancientwarfarenpc:iron_spear",
+                    "weight": 3
+                }
+            ]
+        },
+        {
+            "name": "ressources",
+            "rolls": {
+                "min": 1,
+                "max": 2
+            },
+            "bonus_rolls": {
+                "min": 1,
+                "max": 2
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:sugar",
                     "weight": 5,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 3
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:glowstone_dust",
+                    "weight": 3,
                     "functions": [
                         {
                             "function": "set_count",
@@ -65,13 +70,41 @@
                 },
                 {
                     "type": "item",
-                    "name": "gold_ingot",
+                    "name": "minecraft:spider_eye",
+                    "weight": 4,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 3
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:fermented_spider_eye",
                     "weight": 2,
                     "functions": [
                         {
                             "function": "set_count",
                             "count": {
                                 "min": 1,
+                                "max": 2
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:speckled_melon",
+                    "weight": 4,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
                                 "max": 3
                             }
                         }
@@ -79,8 +112,68 @@
                 },
                 {
                     "type": "item",
-                    "name": "diamond",
+                    "name": "minecraft:rabbit_foot",
                     "weight": 1,
+                    "quality": 2
+                }
+            ]
+        },
+        {
+            "name": "potions",
+            "rolls": {
+                "min": 1,
+                "max": 2
+            },
+            "bonus_rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:potion",
+                    "weight": 5,
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Potion:\"minecraft:water\"}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:potion",
+                    "weight": 3,
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Potion:\"minecraft:thick\"}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:potion",
+                    "weight": 3,
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Potion:\"minecraft:awkward\"}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:potion",
+                    "weight": 2,
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Potion:\"minecraft:mundane\"}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:experience_bottle",
+                    "weight": 3,
                     "functions": [
                         {
                             "function": "set_count",
@@ -93,56 +186,68 @@
                 },
                 {
                     "type": "item",
-                    "name": "ancientwarfarenpc:shield_tribal_1",
-                    "weight": 3,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 2
-                            }
-                        }
-                    ]
+                    "name": "minecraft:glass_bottle",
+                    "weight": 3
                 },
                 {
                     "type": "item",
-                    "name": "ancientwarfarenpc:shield_tribal_2",
-                    "weight": 3,
+                    "name": "minecraft:potion",
+                    "weight": 1,
+                    "quality": 2,
                     "functions": [
                         {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 2
-                            }
+                            "function": "set_nbt",
+                            "tag": "{CustomPotionEffects:[{Duration:4800,Id:26b,Amplifier:1b},{Duration:600,Id:27b,Amplifier:0b}],CustomPotionColor:65459,HideFlags:32,display:{Lore:[\"Suspicious\"],Name:\"Gnome Juice\"}}"
                         }
                     ]
-                },
+                }
+            ]
+        },
+        {
+            "name": "food",
+            "rolls": {
+                "min": 1,
+                "max": 2
+            },
+            "entries": [
                 {
                     "type": "item",
-                    "name": "beef",
+                    "name": "minecraft:red_mushroom",
                     "weight": 5,
                     "functions": [
                         {
                             "function": "set_count",
                             "count": {
                                 "min": 1,
-                                "max": 6
+                                "max": 3
                             }
                         }
                     ]
                 },
                 {
                     "type": "item",
-                    "name": "gold_nugget",
-                    "weight": 3,
+                    "name": "minecraft:brown_mushroom",
+                    "weight": 5,
                     "functions": [
                         {
                             "function": "set_count",
                             "count": {
                                 "min": 1,
-                                "max": 7
+                                "max": 3
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:bread",
+                    "weight": 5,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 3
                             }
                         }
                     ]

--- a/src/main/resources/assets/ancientwarfare/loot_tables/chests/guardian.json
+++ b/src/main/resources/assets/ancientwarfare/loot_tables/chests/guardian.json
@@ -1,102 +1,70 @@
 {
     "pools": [
         {
-            "name":"main", 
+            "name": "weapons",
             "rolls": {
-                "min": 1,
-                "max": 4
+                "min": 0,
+                "max": 1
             },
             "entries": [
                 {
                     "type": "item",
-                    "name": "milk_bucket",
-                    "weight": 6,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 2
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "cooked_beef",
-                    "weight": 5,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 5
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "leather",
-                    "weight": 6,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 6
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "ancientwarfarenpc:iron_spear",
-                    "weight": 5,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 2
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "torch",
-                    "weight": 3,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 6
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "gold_ingot",
-                    "weight": 2,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 3
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "diamond",
+                    "name": "ancientwarfarenpc:golden_lance",
                     "weight": 1,
                     "functions": [
                         {
+                            "function": "enchant_with_levels",
+                            "levels": {
+                                "min": 0,
+                                "max": 3
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "ancientwarfarenpc:golden_spear",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "enchant_with_levels",
+                            "levels": {
+                                "min": 0,
+                                "max": 3
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "ancientwarfarenpc:diamond_shield",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "enchant_with_levels",
+                            "levels": {
+                                "min": 0,
+                                "max": 3
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "ressources",
+            "rolls": {
+                "min": 1,
+                "max": 2
+            },
+            "bonus_rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:gold_nugget",
+                    "weight": 5,
+                    "functions": [
+                        {
                             "function": "set_count",
                             "count": {
                                 "min": 1,
@@ -107,56 +75,94 @@
                 },
                 {
                     "type": "item",
-                    "name": "ancientwarfarenpc:shield_tribal_1",
-                    "weight": 3,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 2
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "ancientwarfarenpc:shield_tribal_2",
-                    "weight": 3,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 2
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "beef",
+                    "name": "minecraft:iron_ingot",
                     "weight": 5,
                     "functions": [
                         {
                             "function": "set_count",
                             "count": {
                                 "min": 1,
-                                "max": 6
+                                "max": 3
                             }
                         }
                     ]
                 },
                 {
                     "type": "item",
-                    "name": "gold_nugget",
+                    "name": "minecraft:gold_ingot",
                     "weight": 3,
                     "functions": [
                         {
                             "function": "set_count",
                             "count": {
                                 "min": 1,
-                                "max": 7
+                                "max": 3
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:diamond",
+                    "weight": 1
+                }
+            ]
+        },
+        {
+            "name": "food",
+            "rolls": {
+                "min": 1,
+                "max": 2
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:golden_apple",
+                    "weight": 1
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:golden_carrot",
+                    "weight": 1
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:bread",
+                    "weight": 3,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 3
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:cooked_porkchop",
+                    "weight": 3,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 3
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:cooked_beef",
+                    "weight": 3,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 3
                             }
                         }
                     ]

--- a/src/main/resources/assets/ancientwarfare/loot_tables/chests/guild.json
+++ b/src/main/resources/assets/ancientwarfare/loot_tables/chests/guild.json
@@ -1,57 +1,143 @@
 {
     "pools": [
         {
-            "name":"main", 
+            "name": "weapons",
             "rolls": {
-                "min": 1,
-                "max": 4
+                "min": 0,
+                "max": 1
             },
             "entries": [
                 {
                     "type": "item",
-                    "name": "milk_bucket",
-                    "weight": 6,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 2
-                            }
-                        }
-                    ]
+                    "name": "ancientwarfarenpc:iron_shield",
+                    "weight": 2
                 },
                 {
                     "type": "item",
-                    "name": "cooked_beef",
-                    "weight": 5,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 5
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "leather",
-                    "weight": 6,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 6
-                            }
-                        }
-                    ]
+                    "name": "minecraft:bow",
+                    "weight": 3
                 },
                 {
                     "type": "item",
                     "name": "ancientwarfarenpc:iron_spear",
+                    "weight": 3
+                }
+            ]
+        },
+        {
+            "name": "ressources",
+            "rolls": {
+                "min": 1,
+                "max": 2
+            },
+            "bonus_rolls": {
+                "min": 1,
+                "max": 2
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:iron_ingot",
+                    "weight": 5,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 3
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:gold_nugget",
+                    "weight": 5,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 3
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:book",
+                    "weight": 5
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:paper",
+                    "weight": 5,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 3
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "ancientwarfare:stone_quill",
+                    "weight": 5
+                }
+            ]
+        },
+        {
+            "name": "food",
+            "rolls": {
+                "min": 2,
+                "max": 5
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:bread",
+                    "weight": 5
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:cooked_mutton",
+                    "weight": 5
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:rabbit_stew",
+                    "weight": 5
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:cooked_rabbit",
+                    "weight": 5
+                },
+                {
+                    "type": "item",
+                    "name": "ancientwarfarenpc:food_bundle",
+                    "weight": 3
+                }
+            ]
+        },
+        {
+            "name":"coins", 
+            "rolls": {
+                "min": 0,
+                "max": 2
+            },
+            "bonus_rolls": {
+                "min": 1,
+                "max": 2
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "ancientwarfarenpc:coin",
+                    "entryName": "coin_copper",
                     "weight": 5,
                     "functions": [
                         {
@@ -60,93 +146,61 @@
                                 "min": 1,
                                 "max": 2
                             }
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{metal:\"copper\"}"
                         }
                     ]
                 },
-                {
+				{
                     "type": "item",
-                    "name": "gold_ingot",
+                    "name": "ancientwarfarenpc:coin",
+                    "entryName": "coin_silver",
                     "weight": 2,
                     "functions": [
                         {
                             "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 3
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "diamond",
-                    "weight": 1,
-                    "functions": [
+                            "count": 1
+                        },
                         {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 3
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "ancientwarfarenpc:shield_tribal_1",
-                    "weight": 3,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 2
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "ancientwarfarenpc:shield_tribal_2",
-                    "weight": 3,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 2
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "beef",
-                    "weight": 5,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 6
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "gold_nugget",
-                    "weight": 3,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 7
-                            }
+                            "function": "set_nbt",
+                            "tag": "{metal:\"silver\"}"
                         }
                     ]
                 }
+            ]
+        },
+        {
+            "name": "orders",
+            "rolls": {
+                "min": 0,
+                "max": 2
+            },
+            "bonus_rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "ancientwarfarenpc:trade_order",
+                    "weight": 5
+                },
+                {
+                    "type": "item",
+                    "name": "ancientwarfarenpc:upkeep_order",
+                    "weight": 5
+                },
+                {
+                    "type": "item",
+                    "name": "ancientwarfare:research_note",
+                    "weight": 5,
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{researchName:\"trade\"}"
+                        }
+                    ]
+                }
+            
             ]
         }
     ]

--- a/src/main/resources/assets/ancientwarfare/loot_tables/chests/nogg.json
+++ b/src/main/resources/assets/ancientwarfare/loot_tables/chests/nogg.json
@@ -9,20 +9,6 @@
             "entries": [
                 {
                     "type": "item",
-                    "name": "milk_bucket",
-                    "weight": 6,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 2
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
                     "name": "apple",
                     "weight": 3,
                     "functions": [
@@ -39,20 +25,6 @@
                     "type": "item",
                     "name": "torch",
                     "weight": 3,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 6
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "porkchop",
-                    "weight": 5,
                     "functions": [
                         {
                             "function": "set_count",
@@ -93,21 +65,49 @@
                 },
                 {
                     "type": "item",
-                    "name": "leather",
-                    "weight": 6,
+                    "name": "ancientwarfarenpc:iron_halberd",
+                    "weight": 4,
                     "functions": [
                         {
                             "function": "set_count",
                             "count": {
                                 "min": 1,
-                                "max": 6
+                                "max": 2
                             }
                         }
                     ]
                 },
                 {
                     "type": "item",
-                    "name": "ancientwarfarenpc:iron_spear",
+                    "name": "ancientwarfarenpc:shield_round_5",
+                    "weight": 3,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 2
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name":"coins", 
+            "rolls": {
+                "min": 0,
+                "max": 2
+            },
+            "bonus_rolls": {
+                "min": 1,
+                "max": 2
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "ancientwarfarenpc:coin",
+                    "entryName": "coin_copper",
                     "weight": 5,
                     "functions": [
                         {
@@ -116,76 +116,29 @@
                                 "min": 1,
                                 "max": 2
                             }
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{metal:\"copper\"}"
                         }
                     ]
                 },
-                {
+				{
                     "type": "item",
-                    "name": "gold_ingot",
+                    "name": "ancientwarfarenpc:coin",
+                    "entryName": "coin_silver",
                     "weight": 2,
                     "functions": [
                         {
                             "function": "set_count",
                             "count": {
                                 "min": 1,
-                                "max": 3
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "diamond",
-                    "weight": 1,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 3
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "ancientwarfarenpc:shield_round_3",
-                    "weight": 3,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
                                 "max": 2
                             }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "ancientwarfarenpc:shield_round_4",
-                    "weight": 3,
-                    "functions": [
+                        },
                         {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 2
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "gold_nugget",
-                    "weight": 3,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 7
-                            }
+                            "function": "set_nbt",
+                            "tag": "{metal:\"silver\"}"
                         }
                     ]
                 }

--- a/src/main/resources/assets/ancientwarfare/loot_tables/chests/nogg.json
+++ b/src/main/resources/assets/ancientwarfare/loot_tables/chests/nogg.json
@@ -65,15 +65,37 @@
                 },
                 {
                     "type": "item",
-                    "name": "ancientwarfarenpc:iron_halberd",
-                    "weight": 4,
+                    "name": "cooked_beef",
+                    "weight": 5,
                     "functions": [
                         {
                             "function": "set_count",
                             "count": {
                                 "min": 1,
-                                "max": 2
+                                "max": 5
                             }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "ancientwarfarenpc:iron_halberd",
+                    "weight": 4,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:iron_sword",
+                    "weight": 4,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
                         }
                     ]
                 },
@@ -81,6 +103,17 @@
                     "type": "item",
                     "name": "ancientwarfarenpc:shield_round_5",
                     "weight": 3,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:emerald",
+                    "weight": 2,
                     "functions": [
                         {
                             "function": "set_count",
@@ -131,10 +164,7 @@
                     "functions": [
                         {
                             "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 2
-                            }
+                            "count": 1
                         },
                         {
                             "function": "set_nbt",

--- a/src/main/resources/assets/ancientwarfare/loot_tables/chests/vyncan.json
+++ b/src/main/resources/assets/ancientwarfare/loot_tables/chests/vyncan.json
@@ -1,24 +1,257 @@
 {
     "pools": [
         {
-            "name": "main",
-            "rolls": 1,
+            "name": "vyncan_weapon",
+            "rolls": {
+                "min": 1,
+                "max": 2
+            },
+            "bonus_rolls": 1,
             "entries": [
                 {
                     "type": "item",
-                    "name": "ancientwarfarenpc:coin",
-                    "weight": 1,
+                    "name": "ancientwarfarenpc:macuahuitl",
+                    "weight": 4,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "ancientwarfarenpc:obsidian_spear",
+                    "weight": 3,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "ancientwarfarenpc:stone_shield",
+                    "weight": 4,
                     "functions": [
                         {
                             "function": "set_count",
                             "count": {
                                 "min": 1,
-                                "max": 8
+                                "max": 2
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:bow",
+                    "weight": 3,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "ressources",
+            "rolls": {
+                "min": 2,
+                "max": 4
+            },
+            "bonus_rolls": {
+                "min": 1,
+                "max": 2
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:leather",
+                    "weight": 5,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 3
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:rabbit_hide",
+                    "weight": 3,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 2
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:flint",
+                    "weight": 4,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 3
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:gold_nugget",
+                    "weight": 2,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 2
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "food",
+            "rolls": {
+                "min": 1,
+                "max": 2
+            },
+            "bonus_rolls": {
+                "min": 1,
+                "max": 2
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:cooked_beef",
+                    "weight": 5,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 3
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:cooked_porkchop",
+                    "weight": 3,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 2
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:cooked_chicken",
+                    "weight": 4,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 3
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:cooked_mutton",
+                    "weight": 2,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 2
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:bread",
+                    "weight": 4,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 3
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name":"coins", 
+            "rolls": {
+                "min": 0,
+                "max": 2
+            },
+            "bonus_rolls": {
+                "min": 1,
+                "max": 2
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "ancientwarfarenpc:coin",
+                    "entryName": "coin_copper",
+                    "weight": 5,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 2
                             }
                         },
                         {
                             "function": "set_nbt",
                             "tag": "{metal:\"copper\"}"
+                        }
+                    ]
+                },
+				{
+                    "type": "item",
+                    "name": "ancientwarfarenpc:coin",
+                    "entryName": "coin_silver",
+                    "weight": 2,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{metal:\"silver\"}"
                         }
                     ]
                 }

--- a/src/main/resources/assets/ancientwarfare/loot_tables/chests/vyncan_jungle.json
+++ b/src/main/resources/assets/ancientwarfare/loot_tables/chests/vyncan_jungle.json
@@ -1,16 +1,91 @@
 {
     "pools": [
         {
-            "name":"main", 
+            "name": "vyncan_weapon",
             "rolls": {
                 "min": 1,
-                "max": 4
+                "max": 2
+            },
+            "bonus_rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "ancientwarfarenpc:macuahuitl",
+                    "weight": 4,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "ancientwarfarenpc:obsidian_spear",
+                    "weight": 3,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "ancientwarfarenpc:stone_shield",
+                    "weight": 4,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 2
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:bow",
+                    "weight": 3,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "ressources",
+            "rolls": {
+                "min": 2,
+                "max": 6
+            },
+            "bonus_rolls": {
+                "min": 1,
+                "max": 2
             },
             "entries": [
                 {
                     "type": "item",
-                    "name": "milk_bucket",
-                    "weight": 6,
+                    "name": "minecraft:leather",
+                    "weight": 5,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 3
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:rabbit_hide",
+                    "weight": 3,
                     "functions": [
                         {
                             "function": "set_count",
@@ -23,49 +98,7 @@
                 },
                 {
                     "type": "item",
-                    "name": "cooked_beef",
-                    "weight": 5,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 5
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "leather",
-                    "weight": 6,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 6
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "ancientwarfarenpc:iron_spear",
-                    "weight": 5,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 2
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "gold_ingot",
+                    "name": "minecraft:flint",
                     "weight": 2,
                     "functions": [
                         {
@@ -79,8 +112,54 @@
                 },
                 {
                     "type": "item",
-                    "name": "diamond",
-                    "weight": 1,
+                    "name": "minecraft:gold_nugget",
+                    "weight": 2,
+                    "quality": 2,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 2
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:dye",
+                    "weight": 6,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 3
+                            }
+                        },
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "food",
+            "rolls": {
+                "min": 1,
+                "max": 2
+            },
+            "bonus_rolls": {
+                "min": 1,
+                "max": 2
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:cooked_beef",
+                    "weight": 5,
                     "functions": [
                         {
                             "function": "set_count",
@@ -93,7 +172,7 @@
                 },
                 {
                     "type": "item",
-                    "name": "ancientwarfarenpc:shield_tribal_1",
+                    "name": "minecraft:cooked_porkchop",
                     "weight": 3,
                     "functions": [
                         {
@@ -107,8 +186,22 @@
                 },
                 {
                     "type": "item",
-                    "name": "ancientwarfarenpc:shield_tribal_2",
-                    "weight": 3,
+                    "name": "minecraft:cooked_chicken",
+                    "weight": 4,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 3
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:cooked_mutton",
+                    "weight": 2,
                     "functions": [
                         {
                             "function": "set_count",
@@ -121,29 +214,77 @@
                 },
                 {
                     "type": "item",
-                    "name": "beef",
+                    "name": "minecraft:bread",
+                    "weight": 4,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 3
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:melon",
+                    "weight": 6,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 2,
+                                "max": 5
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name":"coins", 
+            "rolls": {
+                "min": 0,
+                "max": 2
+            },
+            "bonus_rolls": {
+                "min": 1,
+                "max": 2
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "ancientwarfarenpc:coin",
+                    "entryName": "coin_copper",
                     "weight": 5,
                     "functions": [
                         {
                             "function": "set_count",
                             "count": {
                                 "min": 1,
-                                "max": 6
+                                "max": 2
                             }
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{metal:\"copper\"}"
                         }
                     ]
                 },
-                {
+				{
                     "type": "item",
-                    "name": "gold_nugget",
-                    "weight": 3,
+                    "name": "ancientwarfarenpc:coin",
+                    "entryName": "coin_silver",
+                    "weight": 2,
                     "functions": [
                         {
                             "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 7
-                            }
+                            "count": 1
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{metal:\"silver\"}"
                         }
                     ]
                 }

--- a/src/main/resources/assets/ancientwarfare/loot_tables/chests/vyncan_mesa.json
+++ b/src/main/resources/assets/ancientwarfare/loot_tables/chests/vyncan_mesa.json
@@ -1,16 +1,42 @@
 {
     "pools": [
         {
-            "name":"main", 
+            "name": "vyncan_weapon",
             "rolls": {
                 "min": 1,
-                "max": 4
+                "max": 2
+            },
+            "bonus_rolls": {
+                "min": 1,
+                "max": 2
             },
             "entries": [
                 {
                     "type": "item",
-                    "name": "milk_bucket",
-                    "weight": 6,
+                    "name": "ancientwarfarenpc:macuahuitl",
+                    "weight": 4,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "ancientwarfarenpc:obsidian_spear",
+                    "weight": 3,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "ancientwarfarenpc:stone_shield",
+                    "weight": 4,
                     "functions": [
                         {
                             "function": "set_count",
@@ -23,36 +49,32 @@
                 },
                 {
                     "type": "item",
-                    "name": "cooked_beef",
-                    "weight": 5,
+                    "name": "minecraft:bow",
+                    "weight": 3,
                     "functions": [
                         {
                             "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 5
-                            }
+                            "count": 1
                         }
                     ]
-                },
+                }
+            ]
+        },
+        {
+            "name": "ressources",
+            "rolls": {
+                "min": 1,
+                "max": 5
+            },
+            "bonus_rolls": {
+                "min": 1,
+                "max": 2
+            },
+            "entries": [
                 {
                     "type": "item",
-                    "name": "leather",
-                    "weight": 6,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 6
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "ancientwarfarenpc:iron_spear",
-                    "weight": 5,
+                    "name": "minecraft:rabbit_hide",
+                    "weight": 3,
                     "functions": [
                         {
                             "function": "set_count",
@@ -65,41 +87,65 @@
                 },
                 {
                     "type": "item",
-                    "name": "gold_ingot",
+                    "name": "minecraft:gold_nugget",
+                    "weight": 4,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 2
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:gold_ingot",
+                    "weight": 2,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "food",
+            "rolls": {
+                "min": 1,
+                "max": 2
+            },
+            "bonus_rolls": {
+                "min": 1,
+                "max": 2
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:cooked_beef",
+                    "weight": 5,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": {
+                                "min": 1,
+                                "max": 3
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:cooked_mutton",
                     "weight": 2,
                     "functions": [
                         {
                             "function": "set_count",
                             "count": {
                                 "min": 1,
-                                "max": 3
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "diamond",
-                    "weight": 1,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 3
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "item",
-                    "name": "ancientwarfarenpc:shield_tribal_1",
-                    "weight": 3,
-                    "functions": [
-                        {
-                            "function": "set_count",
-                            "count": {
-                                "min": 1,
                                 "max": 2
                             }
                         }
@@ -107,43 +153,78 @@
                 },
                 {
                     "type": "item",
-                    "name": "ancientwarfarenpc:shield_tribal_2",
-                    "weight": 3,
+                    "name": "minecraft:bread",
+                    "weight": 4,
                     "functions": [
                         {
                             "function": "set_count",
                             "count": {
                                 "min": 1,
-                                "max": 2
+                                "max": 3
                             }
                         }
                     ]
                 },
                 {
                     "type": "item",
-                    "name": "beef",
+                    "name": "minecraft:potion",
+                    "weight": 4,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Potion:\"minecraft:water\"}"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name":"coins", 
+            "rolls": {
+                "min": 0,
+                "max": 2
+            },
+            "bonus_rolls": {
+                "min": 1,
+                "max": 2
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "ancientwarfarenpc:coin",
+                    "entryName": "coin_copper",
                     "weight": 5,
                     "functions": [
                         {
                             "function": "set_count",
                             "count": {
                                 "min": 1,
-                                "max": 6
+                                "max": 2
                             }
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{metal:\"copper\"}"
                         }
                     ]
                 },
-                {
+				{
                     "type": "item",
-                    "name": "gold_nugget",
-                    "weight": 3,
+                    "name": "ancientwarfarenpc:coin",
+                    "entryName": "coin_silver",
+                    "weight": 2,
                     "functions": [
                         {
                             "function": "set_count",
-                            "count": {
-                                "min": 1,
-                                "max": 7
-                            }
+                            "count": 1
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{metal:\"silver\"}"
                         }
                     ]
                 }


### PR DESCRIPTION
## Loot tables
### Noggs
 - coin roll
 - main roll
### Vyncan
 - Coin roll
 - Weapon roll (macuahuitl, obsidian spear, stone shield, bow, arrow)
 - ressource roll (leather, rabbit hide, silex, gold nugget)
 - food roll (cooked beef, porkchop, chicken, mutton, bread)
### Vyncan Jungle
 - Coin roll
 - Weapon roll (macuahuitl, obsidian spear, stone shield, bow, arrow)
 - ressource roll (leather, rabbit hide, silex, gold nugget, cocoa)
 - food roll (cooked beef, porkchop, chicken, mutton, bread, melon)
### Vyncan Mesa
 - Coin roll
 - Weapon roll (macuahuitl, obsidian spear, stone shield, bow, arrow)
 - ressource roll (rabbit hide, gold nugget, gold ingot)
 - food roll (cooked beef, mutton, bread, water bottle)
### Dwarf
 - weapon roll (iron axe, iron halberd)
 - tool roll (iron pickaxe, very rare diamond pickaxe, iron shovel, minecart, rail)
 - raw ore roll (iron ore, gold ore)
 - processed ore roll (iron ingot, gold ingot, diamond, emerald)
 - food roll (mushroom stew, rabbit stew, rare haste potion)
 - rubble roll (cobblestone, dirt, gravel) - negative quality.
### Gnome
 - weapon roll (iron spear, iron sword, iron shield)
 - ressource roll (sugar, glowstone, spider eye, fermented spider eye, glistering melon, RARE rabit foot)
 - potions (water bottle, thick/awkward/mundane potions, xp bottles, empty bottle, gnome juice)
 - food roll (mushrooms)
### Guardians
 - weapon roll (golden lance, golden spear, diamond shield)
 - food roll (golden apple, golden carrot, bread, cooked porkchop, cooked beef)
 - ressource roll (gold nugget, iron ingot, gold ingot, diamond)
### Guild
 - weapon roll (iron spear, iron shield)
 - food roll (bread, food bundle, cooked mutton, rabbit stew, cooked rabbit)
 - ressource roll (iron ingot, gold nugget, book, paper, stone quill)
 - coin roll
 - order roll (upkeep roll, trade order, trade research note)