### PR TITLE
NPC Keep Equipment Feature

### DIFF
--- a/src/main/java/net/shadowmage/ancientwarfare/npc/ai/owned/NpcAIPlayerOwnedPriest.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/npc/ai/owned/NpcAIPlayerOwnedPriest.java
@@ -11,6 +11,7 @@ import net.shadowmage.ancientwarfare.npc.entity.NpcPlayerOwned;
 import net.shadowmage.ancientwarfare.npc.item.ItemNpcSpawner;
 import net.shadowmage.ancientwarfare.npc.tile.TileTownHall;
 import net.shadowmage.ancientwarfare.npc.tile.TileTownHall.NpcDeathEntry;
+import static net.shadowmage.ancientwarfare.npc.config.AWNPCStatics.npcKeepEquipment;
 
 import java.util.Collections;
 import java.util.List;
@@ -81,14 +82,12 @@ public class NpcAIPlayerOwnedPriest extends NpcAI<NpcPlayerOwned> {
 		NpcBase resdNpc = ItemNpcSpawner.createNpcFromItem(npc.world, entryToRes.stackToSpawn);
 		entryToRes.beingResurrected = false;
 		if (resdNpc != null) {
-			if (!AWNPCStatics.persistOrdersOnDeath) {
-				resdNpc.ordersStack = ItemStack.EMPTY;
-				resdNpc.upkeepStack = ItemStack.EMPTY;
+			if (!npcKeepEquipment) {
+				for (EntityEquipmentSlot slot : EntityEquipmentSlot.values()) {
+					resdNpc.setItemStackToSlot(slot, ItemStack.EMPTY);
+				}
+				resdNpc.setShieldStack(ItemStack.EMPTY);
 			}
-			for (EntityEquipmentSlot slot : EntityEquipmentSlot.values()) {
-				resdNpc.setItemStackToSlot(slot, ItemStack.EMPTY);
-			}
-			resdNpc.setShieldStack(ItemStack.EMPTY);
 			resdNpc.setOwner(npc.getOwner());
 			resdNpc.setHealth(resdNpc.getMaxHealth() / 2);
 			resdNpc.setPositionAndRotation(npc.posX, npc.posY, npc.posZ, npc.rotationYaw, npc.rotationPitch);

--- a/src/main/java/net/shadowmage/ancientwarfare/npc/config/AWNPCStatics.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/npc/config/AWNPCStatics.java
@@ -37,6 +37,7 @@ public class AWNPCStatics extends ModConfiguration {
 	public static double archerRange = 60.0;
 	public static boolean vanillaEquipmentDropRate = true;
 	public static double npcLevelDamageMultiplier = 0.05;//damage bonus per npc level.  @ level 10 they do 2x the damage as at lvl 0
+	public static boolean npcKeepEquipment = false;
 
 
 	/* ********************************************CLIENT SETTINGS************************************************ */
@@ -99,8 +100,10 @@ public class AWNPCStatics extends ModConfiguration {
 
 		npcAllowUpkeepAnyInventory = config.get(serverOptions, "allow_upkeep_any_inventory", npcAllowUpkeepAnyInventory, "Allow NPC upkeep location at any inventory\nDefault=" + npcAllowUpkeepAnyInventory + "\n" + "By default, the Upkeep Order slip can be used to assign upkeep locations to any valid inventory block.\n" + "If set to false, only Town Hall blocks will be allowed as valid upkeep locations.").getBoolean();
 
-		townMaxRange = config.get(serverOptions, "town_hall_max_range", townMaxRange, "Town Hall Max Activation Range\nDefault=" + townMaxRange + "\n" + "How many blocks can a Town Hall be away from an NPC, while still detecting their death for possible resurrection.\n" + "This is a maximum, for server efficiency sake. Lower individual values can be setup from each block interaction GUI.").getInt();
+		npcKeepEquipment = config.get(serverOptions, "npc_keep_equipment", npcKeepEquipment, "Allow owned NPCs to keep their equipment after death\nDefault=" + npcKeepEquipment + "\n" + "By default, player owned NPCs drop their items after death.\n" + "If set to true, player owned NPCs respawn with all their items and will not drop equipment on death").getBoolean();
 
+		townMaxRange = config.get(serverOptions, "town_hall_max_range", townMaxRange, "Town Hall Max Activation Range\nDefault=" + townMaxRange + "\n" + "How many blocks can a Town Hall be away from an NPC, while still detecting their death for possible resurrection.\n" + "This is a maximum, for server efficiency sake. Lower individual values can be setup from each block interaction GUI.").getInt();
+		
 		townUpdateFreq = config.get(serverOptions, "town_hall_ticks", townUpdateFreq, "Default=" + townUpdateFreq + "\n" + "How many game ticks should pass between Town Hall updates." + "This affect how an NPC can change its selected Town Hall by moving to different places.\n" + "Lower values will make an NPC change its Town Hall faster, but is more costly for a server.\n").getInt();
 
 		loadDefaultSkinPack = config.get(clientOptions, "load_default_skin_pack", loadDefaultSkinPack, "Load Default Skin Pack\nDefault=true\n" + "If true, default skin pack will be loaded.\n" + "If false, default skin pack will NOT be loaded -- you will need to supply your own\n" + "skin packs or all npcs will use the default skin.").getBoolean();

--- a/src/main/java/net/shadowmage/ancientwarfare/npc/entity/NpcPlayerOwned.java
+++ b/src/main/java/net/shadowmage/ancientwarfare/npc/entity/NpcPlayerOwned.java
@@ -30,6 +30,7 @@ import net.shadowmage.ancientwarfare.npc.orders.UpkeepOrder;
 import net.shadowmage.ancientwarfare.npc.registry.NpcDefault;
 import net.shadowmage.ancientwarfare.npc.registry.NpcDefaultsRegistry;
 import net.shadowmage.ancientwarfare.npc.tile.TileTownHall;
+import static net.shadowmage.ancientwarfare.npc.config.AWNPCStatics.npcKeepEquipment;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -275,12 +276,14 @@ public abstract class NpcPlayerOwned extends NpcBase implements IKeepFood, INpc 
 
 	@Override
 	protected void dropEquipment(boolean wasRecentlyHit, int lootingModifier) {
-		for (EntityEquipmentSlot slot : EntityEquipmentSlot.values()) {
-			ItemStack itemstack = this.getItemStackFromSlot(slot);
-			if (!itemstack.isEmpty()) {
-				this.entityDropItem(itemstack, 0.0F);
+		if (!npcKeepEquipment) {
+			for (EntityEquipmentSlot slot : EntityEquipmentSlot.values()) {
+				ItemStack itemstack = this.getItemStackFromSlot(slot);
+				if (!itemstack.isEmpty()) {
+					this.entityDropItem(itemstack, 0.0F);
+				}
+				setItemStackToSlot(slot, ItemStack.EMPTY);			
 			}
-			setItemStackToSlot(slot, ItemStack.EMPTY);
 		}
 		if (!AWNPCStatics.persistOrdersOnDeath) {
 			if (!ordersStack.isEmpty()) {


### PR DESCRIPTION
This adds a new option to the Ancient Warfare NPC config, npc_keep_equipment.
It will be set to false by default.

If set to true,
The NPC will keep their equipment when they are revived.
The NPC will not drop their equipment on death.