### PR TITLE
Fix duplicate errors in gnome loot table

### DIFF
--- a/src/main/resources/assets/ancientwarfare/loot_tables/chests/gnome.json
+++ b/src/main/resources/assets/ancientwarfare/loot_tables/chests/gnome.json
@@ -128,6 +128,7 @@
             "entries": [
                 {
                     "type": "item",
+                    "entryName": "water_bottle",
                     "name": "minecraft:potion",
                     "weight": 5,
                     "functions": [
@@ -139,6 +140,7 @@
                 },
                 {
                     "type": "item",
+                    "entryName": "thick_potion",
                     "name": "minecraft:potion",
                     "weight": 3,
                     "functions": [
@@ -150,6 +152,7 @@
                 },
                 {
                     "type": "item",
+                    "entryName": "awkward_potion",
                     "name": "minecraft:potion",
                     "weight": 3,
                     "functions": [
@@ -161,6 +164,7 @@
                 },
                 {
                     "type": "item",
+                    "entryName": "mundane_potion",
                     "name": "minecraft:potion",
                     "weight": 2,
                     "functions": [
@@ -191,6 +195,7 @@
                 },
                 {
                     "type": "item",
+                    "entryName": "gnome_juice",
                     "name": "minecraft:potion",
                     "weight": 1,
                     "quality": 2,


### PR DESCRIPTION
```
[21:04:46] [Server thread/ERROR] [minecraft/LootTableManager]: Couldn't load loot table ancientwarfare:chests/gnome from jar:file:/home/container/./mods/ancientwarfare-1.12.2-2.10.2.jar!/assets/ancientwarfare/loot_tables/chests/gnome.json
com.google.gson.JsonParseException: Loot Table "ancientwarfare:chests/gnome" Duplicate entry name "minecraft:potion" for pool #-1 entry #1
```